### PR TITLE
getting rid of `main_app` references in layouts

### DIFF
--- a/app/controllers/koudoku/application_controller.rb
+++ b/app/controllers/koudoku/application_controller.rb
@@ -2,5 +2,9 @@ module Koudoku
   class ApplicationController < ::ApplicationController
     layout 'application'
     helper :application
+    
+    # stolen from http://stackoverflow.com/questions/9232175/access-main-app-helpers-when-overridings-a-rails-engine-view-layout#comment44856124_19453140
+    # to solve the problem of having to reference "main_app.$some_model_path" in layouts
+    helper Rails.application.routes.url_helpers 
   end
 end


### PR DESCRIPTION
When devs reference `_url` and `_path` URL helpers in their layouts (shared by Koudoku) they necessarily have to prepend those with `main_app` which is a trip wire for a lot of people. 
Trying to solve that in the most elegant way possible. Inspired by http://stackoverflow.com/questions/9232175/access-main-app-helpers-when-overridings-a-rails-engine-view-layout#comment44856124_19453140